### PR TITLE
minor fix to install.py and .gitignore some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.png
 *.gif
 *.jpg
+aria2c.exe

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.gif
 *.jpg
 aria2c.exe
+sd_hub/hf-logo.svg

--- a/install.py
+++ b/install.py
@@ -10,6 +10,7 @@ orange_ = '\033[38;5;208m'
 blue_ = '\033[38;5;39m'
 reset_ = '\033[0m'
 
+
 def _sub(inputs: List[str]) -> bool:
     try:
         subprocess.run(
@@ -23,6 +24,7 @@ def _sub(inputs: List[str]) -> bool:
     except subprocess.CalledProcessError:
         return False
 
+
 def _check_req(pkg: str, args: str, cmd: str, pkg_list: List[str]) -> None:
     try:
         subprocess.run(
@@ -35,6 +37,7 @@ def _check_req(pkg: str, args: str, cmd: str, pkg_list: List[str]) -> None:
     except FileNotFoundError:
         pkg_list.append(pkg)
         _sub(cmd.split())
+
 
 def _install_req_1() -> None:
     reqs = []
@@ -76,7 +79,8 @@ def _install_req_1() -> None:
                 subprocess.run(
                     [sys.executable, '-m', 'pip', 'install', '-q', pkg]
                 )
-   
+
+
 def _install_req_2() -> None:
     pkg_list: List[str] = []
 
@@ -160,6 +164,7 @@ def _install_req_2() -> None:
             f"Installing SD-Hub requirement: "
             f"{' '.join(f'{blue_}{pkg}{reset_}' for pkg in pkg_list)}"
         )
+
 
 _install_req_1()
 _install_req_2()

--- a/install.py
+++ b/install.py
@@ -1,7 +1,8 @@
+from importlib import metadata
 from packaging import version
 from typing import List, Dict
 from pathlib import Path
-import pkg_resources, subprocess, requests, zipfile, launch, sys, os
+import subprocess, requests, zipfile, launch, sys, os
 
 base = Path(__file__).parent
 req_ = base / "requirements.txt"
@@ -50,12 +51,12 @@ def _install_req_1() -> None:
             if '==' in pkg:
                 pkg_name, pkg_version = pkg.split('==')
                 try:
-                    _version = pkg_resources.get_distribution(pkg_name).version
+                    _version = metadata.version(pkg_name)
                     if version.parse(_version) < version.parse(pkg_version):
                         reqs.append(pkg)
                         names.append(pkg_name)
                         
-                except pkg_resources.DistributionNotFound:
+                except metadata.PackageNotFoundError:
                     reqs.append(pkg)
                     names.append(pkg_name)
                     


### PR DESCRIPTION
use importlib.metadata pkg_resources is deprecated
> pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

.gitignore
```.gitignore
aria2c.exe
sd_hub/hf-logo.svg
```